### PR TITLE
minimal changes to support mTLS and update to new axios nest package

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -1,5 +1,8 @@
-import { DynamicModule, HttpService, HttpModule, Module, Global } from '@nestjs/common';
+import { DynamicModule, Module, Global } from '@nestjs/common';
+import { HttpService, HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Configuration } from './configuration';
+import { Agent } from "https";
+import * as fs from 'fs';
 
 {{#apiInfo}}
 {{#apis}}
@@ -9,7 +12,7 @@ import { {{classname}} } from './{{importPath}}';
 
 @Global()
 @Module({
-  imports:      [ HttpModule ],
+  imports:      [ ],
   exports:      [
     {{#apiInfo}}{{#apis}}{{classname}}{{^-last}},
     {{/-last}}{{/apis}}{{/apiInfo}}
@@ -23,9 +26,43 @@ export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): DynamicModule {
         return {
             module: ApiModule,
-            providers: [ { provide: Configuration, useFactory: configurationFactory } ]
+            providers: [ { provide: Configuration, useFactory: configurationFactory } ],
+            imports: [
+              HttpModule.registerAsync({
+              useFactory: () =>
+                createHttpOptions(
+                  configurationFactory().certPath,
+                  configurationFactory().certKeyPath,
+                  configurationFactory().caPath
+                ),
+            }),
+      ],
+      exports: [HttpModule]
         };
     }
 
     constructor( httpService: HttpService) { }
 }
+
+const createHttpOptions = (
+  certPath?: string,
+  certKeyPath?: string,
+  caPath?: string
+): HttpModuleOptions => {
+  return {
+    timeout: 5001,
+    httpsAgent: certKeyPath && certPath && caPath ? getAgent(certPath, certKeyPath, caPath) : undefined,
+  };
+};
+
+const getAgent = (
+  certPath: string,
+  certKeyPath: string,
+  caPath: string
+): Agent | undefined => {
+  return new Agent({
+    cert: fs.readFileSync(certPath),
+    key: fs.readFileSync(certKeyPath),
+    ca: fs.readFileSync(caPath),
+  });
+};

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -1,7 +1,8 @@
 {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { HttpService, Inject, Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { AxiosResponse } from 'axios';
 import { Observable } from 'rxjs';
 {{#imports}}

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
@@ -1,3 +1,5 @@
+import { HttpModuleOptionsFactory } from "@nestjs/axios";
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;
@@ -5,6 +7,9 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    certPath?: string;
+    certKeyPath?: string;
+    caPath?:string;
 }
 
 export class Configuration {
@@ -13,7 +18,10 @@ export class Configuration {
     password?: string;
     accessToken?: string | (() => string);
     basePath?: string;
-    withCredentials?: boolean;
+    withCredentials?: boolean; 
+    certPath?: string;
+    certKeyPath?: string;
+    caPath?:string;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +30,9 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.certPath =  configurationParameters.certPath;
+        this.certKeyPath =  configurationParameters.certKeyPath;
+        this.caPath = configurationParameters.caPath;
     }
 
     /**


### PR DESCRIPTION
Switch to newer axios package
Make it possible to send over certs/keys/ca for internal mTLS integration.

**Unsolved by this PR - refreshes of short-lived certificates.**