### PR TITLE
incorrect toISOString usage corrected.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -88,7 +88,7 @@ export class {{classname}} {
         {{^isListContainer}}
         if ({{paramName}} !== undefined && {{paramName}} !== null) {
         {{#isDateTime}}
-            queryParameters['{{baseName}}'] = <any>{{paramName}}.toISOString();
+            queryParameters['{{baseName}}'] = (<any>{{paramName}} as any instanceof Date) ? ({{paramName}} as any).toISOString(): {{paramName}};
         {{/isDateTime}}
         {{^isDateTime}}
             queryParameters['{{baseName}}'] = <any>{{paramName}};


### PR DESCRIPTION
strings with format date-time were incorrectly handled.  This seems like a common issue in code that was created long ago for a different language.

I've tried to use these parameters in code, and this seems to work (fix pulled from another PR on same issue for non-Nest generator).