### PR TITLE
Add keep alive

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -74,6 +74,7 @@ const getAgent = (
   caPath: string
 ): Agent | undefined => {
   return new Agent({
+    keepAlive: true,
     cert: fs.readFileSync(certPath),
     key: fs.readFileSync(certKeyPath),
     ca: fs.readFileSync(caPath),

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -1,9 +1,6 @@
 import { DynamicModule, Module, Global } from '@nestjs/common';
 import { HttpService, HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Configuration } from './configuration';
-import { Agent } from "https";
-import * as fs from 'fs';
-import {REQUEST} from "@nestjs/core";
 
 
 {{#apiInfo}}
@@ -11,9 +8,6 @@ import {REQUEST} from "@nestjs/core";
 import { {{classname}} } from './{{importPath}}';
 {{/apis}}
 {{/apiInfo}}
-
-let cachedOptions: HttpModuleOptions | undefined = undefined;
-let nextOptionsRefresh: number = 0;
 
 @Global()
 @Module({
@@ -32,23 +26,10 @@ export class ApiModule {
         return {
             module: ApiModule,
             providers: [ { provide: Configuration, useFactory: configurationFactory } ],
-            imports: [
+            imports: [             
               HttpModule.registerAsync({
-              useFactory: (request) => {
-                if(cachedOptions === undefined || nextOptionsRefresh < new Date().getTime()){                  
-                  //Refresh certs once per hour or on next request.  Should work with AutoCert since they renew 8 hours before the 24 hour cert expires
-                  nextOptionsRefresh = new Date(new Date().getTime() + 60 * 60000).getTime();
-                  cachedOptions = createHttpOptions(
-                      configurationFactory().certPath,
-                      configurationFactory().certKeyPath,
-                      configurationFactory().caPath
-                  )}
-                return cachedOptions;
-              },
-              //abusing inject a bit here, we only use it to be able to reload the cert using the factory above.
-              //in case of unit tests, we don't do this, as it breaks them
-               inject: process.env.NODE_ENV !== "production" ? [] : [REQUEST]
-            }),
+              useFactory: configurationFactory().httpModuleOptionsFactory
+            })
       ],
       exports: [HttpModule]
         };
@@ -56,27 +37,3 @@ export class ApiModule {
 
     constructor( httpService: HttpService) { }
 }
-
-const createHttpOptions = (
-  certPath?: string,
-  certKeyPath?: string,
-  caPath?: string
-): HttpModuleOptions => {
-  return {
-    timeout: 5001,
-    httpsAgent: certKeyPath && certPath && caPath ? getAgent(certPath, certKeyPath, caPath) : undefined,
-  };
-};
-
-const getAgent = (
-  certPath: string,
-  certKeyPath: string,
-  caPath: string
-): Agent | undefined => {
-  return new Agent({
-    keepAlive: true,
-    cert: fs.readFileSync(certPath),
-    key: fs.readFileSync(certKeyPath),
-    ca: fs.readFileSync(caPath),
-  });
-};

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/configuration.mustache
@@ -1,4 +1,4 @@
-import { HttpModuleOptionsFactory } from "@nestjs/axios";
+import {HttpModuleOptions} from "@nestjs/axios";
 
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
@@ -7,9 +7,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
-    certPath?: string;
-    certKeyPath?: string;
-    caPath?:string;
+    httpModuleOptionsFactory?: ()=> Promise<HttpModuleOptions>;
 }
 
 export class Configuration {
@@ -19,9 +17,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean; 
-    certPath?: string;
-    certKeyPath?: string;
-    caPath?:string;
+    httpModuleOptionsFactory?: () => Promise<HttpModuleOptions>;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -30,9 +26,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
-        this.certPath =  configurationParameters.certPath;
-        this.certKeyPath =  configurationParameters.certKeyPath;
-        this.caPath = configurationParameters.caPath;
+        this.httpModuleOptionsFactory =  configurationParameters.httpModuleOptionsFactory;
     }
 
     /**


### PR DESCRIPTION
much more flexible.   defer http options configuration to outside lambda passed into this code.  